### PR TITLE
Instruct heroku to run with the default apache+php setup in `public/`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-apache2 public/


### PR DESCRIPTION
Without this, `vendor/` is wide open (and that's scary)