### PR TITLE
[GH-5] Add ext-tideways to composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "psr/http-message": "^1.0",
         "symfony/process": "^4.2",
         "thecodingmachine/safe": "^0.1.14",
-        "zendframework/zend-diactoros": "^2.1"
+        "zendframework/zend-diactoros": "^2.1",
+        "ext-tideways": "@stable"
     },
     "autoload-dev": {
         "psr-4": {
@@ -42,7 +43,8 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.3.4"
+            "php": "7.3.4",
+            "ext-tideways": "1.0.0"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c012a0e6529587c6d505e0596ad9264c",
+    "content-hash": "6cb0234b1a23a79aa8962fbb25c7db4b",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -5304,14 +5304,18 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ext-tideways": 0
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3"
+        "php": "^7.3",
+        "ext-tideways": "@stable"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.4"
+        "php": "7.3.4",
+        "ext-tideways": "1.0.0"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,7 @@ parameters:
         - test
     ignoreErrors:
         - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\\Profiler.#'
+        - '#Class Tideways\\Profiler not found.#'
 
 includes:
 	- vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ parameters:
         - src
         - test
     ignoreErrors:
-        - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\Profiler.'
+        - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\Profiler.#'
 
 includes:
 	- vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,8 @@ parameters:
         - public
         - src
         - test
+    ignoreErrors:
+        - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\Profiler.'
 
 includes:
 	- vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ parameters:
         - src
         - test
     ignoreErrors:
-        - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\Profiler.#'
+        - '#Call to static method [a-zA-Z0-9\\_]+\(\) on an unknown class Tideways\\Profiler.#'
 
 includes:
 	- vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,6 +51,12 @@
         <RawObjectIteration errorLevel="info"/>
 
         <InvalidStringClass errorLevel="info"/>
+
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Tideways\Profiler" />
+            </errorLevel>
+        </UndefinedClass>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/public/index.php
+++ b/public/index.php
@@ -176,6 +176,11 @@ use function uniqid;
     $milestone      = MilestoneClosedEvent::fromEventJson($postData['payload']);
     $repositoryName = $milestone->repository();
 
+    if (class_exists('Tideways\Profiler')) {
+        \Tideways\Profiler::setCustomVariable('repository', $repositoryName->owner() . '/' . $reositoryName->name());
+        \Tideways\Profiler::setCustomVariable('version', $milestone->version()->fullReleaseName());
+    }
+
     $repositoryName->assertMatchesOwner($environment->githubOrganisation()); // @TODO limit via ENV?
 
     $repository                  = $repositoryName->uriWithTokenAuthentication($environment->githubToken());

--- a/public/index.php
+++ b/public/index.php
@@ -22,6 +22,7 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Tideways\Profiler;
 use Zend\Diactoros\ServerRequestFactory;
 use const E_NOTICE;
 use const E_STRICT;
@@ -176,9 +177,9 @@ use function uniqid;
     $milestone      = MilestoneClosedEvent::fromEventJson($postData['payload']);
     $repositoryName = $milestone->repository();
 
-    if (class_exists('Tideways\Profiler')) {
-        \Tideways\Profiler::setCustomVariable('repository', $repositoryName->owner() . '/' . $repositoryName->name());
-        \Tideways\Profiler::setCustomVariable('version', $milestone->version()->fullReleaseName());
+    if (class_exists(Profiler::class, false)) {
+        Profiler::setCustomVariable('repository', $repositoryName->owner() . '/' . $repositoryName->name());
+        Profiler::setCustomVariable('version', $milestone->version()->fullReleaseName());
     }
 
     $repositoryName->assertMatchesOwner($environment->githubOrganisation()); // @TODO limit via ENV?

--- a/public/index.php
+++ b/public/index.php
@@ -177,7 +177,7 @@ use function uniqid;
     $repositoryName = $milestone->repository();
 
     if (class_exists('Tideways\Profiler')) {
-        \Tideways\Profiler::setCustomVariable('repository', $repositoryName->owner() . '/' . $reositoryName->name());
+        \Tideways\Profiler::setCustomVariable('repository', $repositoryName->owner() . '/' . $repositoryName->name());
         \Tideways\Profiler::setCustomVariable('version', $milestone->version()->fullReleaseName());
     }
 

--- a/public/index.php
+++ b/public/index.php
@@ -30,6 +30,7 @@ use const E_WARNING;
 use function array_filter;
 use function array_map;
 use function assert;
+use function class_exists;
 use function explode;
 use function is_array;
 use function Safe\file_put_contents;


### PR DESCRIPTION
Steps to activate.

Should be done before rolling this commit out, because the Heroku composer installer needs the information available to get going.

Get Api Key from here: https://app.tideways.io/o/doctrine/automatic-releases/settings

```
heroku config:set HEROKU_PHP_PLATFORM_REPOSITORIES="https://s3-eu-west-1.amazonaws.com/tideways/heroku/"
heroku config:set TIDEWAYS_APIKEY="$APIKEY"
heroku config:set TIDEWAYS_SAMPLERATE=100
```

Fixes #5 