### PR TITLE
Import GPG key without requiring for TTY interaction

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -140,7 +140,7 @@ use function uniqid;
 
         file_put_contents($keyFileName, $keyContents);
 
-        $output = (new Process(['gpg', '--import', $keyFileName]))
+        $output = (new Process(['gpg', '--no-tty', '--batch', '--yes', '--import', $keyFileName]))
             ->mustRun()
             ->getErrorOutput();
 


### PR DESCRIPTION
Fixes: https://app.tideways.io/o/doctrine/automatic-releases/errors?error=8281-1_ca7f508ecdee1e6ce3f01d9d1cc5bd58&page=1&offset=0
Fixes:

```
The command "'gpg' '--import' '/tmp/imported-keyaaDDAl'" failed. Exit Code: 2(Misuse of shell builtins) Working directory: /app/public Output: ================ Error Output: ================ gpg: key A1A906E088C3CEE4: "Doctrine Project Bot (A key used primarily for automated/signed operations inside the Doctrine Project organisation) <doctrinebot@doctrine-project.org>" not changed gpg: key A1A906E088C3CEE4/8510BBA19F2947C3: error sending to agent: Inappropriate ioctl for device gpg: error building skey array: Inappropriate ioctl for device gpg: Total number processed: 1 gpg: unchanged: 1 gpg: secret keys read: 1 in /app/vendor/symfony/process/Process.php:256
```