### PR TITLE
Allow releasing milestones from `master`, create release branches if they don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ TL;DR: when you close a milestone:
  * a `git tag` will be created
  * a github release will be created
  * if not already existing, a release branch will be created
- * a new pull request will be created, porting changes to the next release branch
+ * a new pull request will be created, porting changes to the next release branch from an intermediary branch (e.g. 1.2.3-merge-up-to-1.3.x)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # Release automation for `doctrine/*` packages
 
-This repository is a WIP of the current release automation tool
-that is being developed while at the 
+Please read the [`feature/`](./feature) specification to understand how
+this tool behaves.
 
-## TODOs
-
-This is the proposed workflow:
-
-1. contributor creates PR #123 - RED because not assigned to a milestone
-2. maintainer assigns milestone 1.2.3 to PR #123 - (patch should only be green in this state)
-3. maintainer merges PR #123
-4. maintainer closes milestone 1.2.3
-5. bot picks up hook event: milestone 1.2.3 closed -> create release notes -> tag -> publish
-6. bot creates new branch (from the tag) 1.2.3-merge-up-to-1.3.x
-7. bot opens PR for 1.2.3-merge-up-to-1.3.x
-
+TL;DR: when you close a milestone:
+ * a `git tag` will be created
+ * a github release will be created
+ * if not already existing, a release branch will be created
+ * a new pull request will be created, porting changes to the next release branch

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -1,0 +1,71 @@
+@manually-tested
+Feature: Automated releases
+
+  Scenario: If no major release branch exists, the tool should not create a new major release
+    Given following existing branches:
+      | name  |
+      | 1.0.x |
+    And following open milestones:
+      | name  |
+      | 2.0.0 |
+    When I close milestone "2.0.0"
+    Then the tool should have halted with an error
+
+  Scenario: If no major release branch exists, the tool should not create a new minor release
+    Given following existing branches:
+      | name  |
+      | 1.0.x |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then the tool should have halted with an error
+
+  Scenario: If a major release branch exists, the tool creates a major release from there
+    Given following existing branches:
+      | name   |
+      | 1.0.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 2.0.0 |
+    When I close milestone "2.0.0"
+    Then tag "2.0.0" should have been created on branch "master"
+    And branch "2.0.x" should have been created from "master"
+
+  Scenario: If a major release branch exists, the tool creates a new minor release from there
+    Given following existing branches:
+      | name   |
+      | 1.0.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then tag "1.1.0" should have been created on branch "master"
+    And branch "1.1.x" should have been created from "master"
+
+  Scenario: If a minor release branch exists, the tool creates a new minor release from there
+    Given following existing branches:
+      | name   |
+      | 1.1.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then tag "1.1.0" should have been created on branch "1.1.x"
+    And a new pull request from branch "1.1.x" to "master" should have been created
+
+  Scenario: If a minor release branch exists, the tool creates a new patch release from there
+    Given following existing branches:
+      | name   |
+      | 1.1.x  |
+      | 1.2.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.1 |
+    When I close milestone "1.1.1"
+    Then tag "1.1.1" should have been created on branch "1.1.x"
+    And a new pull request from branch "1.1.x" to "1.2.x" should have been created

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -69,3 +69,14 @@ Feature: Automated releases
     When I close milestone "1.1.1"
     Then tag "1.1.1" should have been created on branch "1.1.x"
     And a new pull request from branch "1.1.x" to "1.2.x" should have been created
+
+  Scenario: If a minor release branch doesn't exist, the tool refuses to create it if a newer one exists
+    Given following existing branches:
+      | name   |
+      | 1.2.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then the tool should have halted with an error

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -80,3 +80,13 @@ Feature: Automated releases
       | 1.1.0 |
     When I close milestone "1.1.0"
     Then the tool should have halted with an error
+
+  Scenario: If a minor release branch doesn't exist, the tool refuses to create a patch release
+    Given following existing branches:
+      | name   |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.1 |
+    When I close milestone "1.1.1"
+    Then the tool should have halted with an error

--- a/public/index.php
+++ b/public/index.php
@@ -135,7 +135,7 @@ use function uniqid;
             ->getOutput()
         );
 
-        $pushedRef = $alias !== null ? $commitRef . ':' . $alias : $symbol;
+        $pushedRef = $alias !== null ? $commitRef . ':refs/heads/' . $alias : $symbol;
 
         (new Process(['git', 'push', 'origin', $pushedRef], $repositoryDirectory))
             ->mustRun();

--- a/public/index.php
+++ b/public/index.php
@@ -129,7 +129,13 @@ use function uniqid;
         string $symbol,
         ?string $alias = null
     ) : void {
-        $pushedRef = $alias !== null ? $symbol . ':' . $alias : $symbol;
+        $commitRef = trim(
+            (new Process(['git', 'rev-parse', $symbol], $repositoryDirectory))
+            ->mustRun()
+            ->getOutput()
+        );
+
+        $pushedRef = $alias !== null ? $commitRef . ':' . $alias : $symbol;
 
         (new Process(['git', 'push', 'origin', $pushedRef], $repositoryDirectory))
             ->mustRun();

--- a/public/index.php
+++ b/public/index.php
@@ -129,15 +129,19 @@ use function uniqid;
         string $symbol,
         ?string $alias = null
     ) : void {
-        $commitRef = trim(
-            (new Process(['git', 'rev-parse', $symbol], $repositoryDirectory))
-            ->mustRun()
-            ->getOutput()
-        );
+        if ($alias === null) {
+            (new Process(['git', 'push', 'origin', $symbol], $repositoryDirectory))
+                ->mustRun();
 
-        $pushedRef = $alias !== null ? $commitRef . ':refs/heads/' . $alias : $symbol;
+            return;
+        }
 
-        (new Process(['git', 'push', 'origin', $pushedRef], $repositoryDirectory))
+        $localTemporaryBranch = uniqid('temporary-branch', true);
+
+        (new Process(['git', 'branch', $localTemporaryBranch, $symbol], $repositoryDirectory))
+            ->mustRun();
+
+        (new Process(['git', 'push', 'origin', $localTemporaryBranch . ':' . $alias], $repositoryDirectory))
             ->mustRun();
     };
 

--- a/src/Git/Value/BranchName.php
+++ b/src/Git/Value/BranchName.php
@@ -64,4 +64,9 @@ final class BranchName
 
         return [$major, $minor];
     }
+
+    public function equals(self $other) : bool
+    {
+        return $other->name === $this->name;
+    }
 }

--- a/src/Git/Value/BranchName.php
+++ b/src/Git/Value/BranchName.php
@@ -69,4 +69,18 @@ final class BranchName
     {
         return $other->name === $this->name;
     }
+
+    public function isForVersion(SemVerVersion $version) : bool
+    {
+        return $this->majorAndMinor() === [$version->major(), $version->minor()];
+    }
+
+    public function isForNewerVersionThan(SemVerVersion $version) : bool
+    {
+        [$major, $minor]      = $this->majorAndMinor();
+        $comparedMajorVersion = $version->major();
+
+        return $major > $comparedMajorVersion
+            || ($comparedMajorVersion === $major && $minor > $version->minor());
+    }
 }

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -54,6 +54,10 @@ final class MergeTargetCandidateBranches
     {
         foreach ($this->sortedBranches as $branch) {
             if ($branch->isNextMajor()) {
+                if (! $version->isNewMinorRelease()) {
+                    return null;
+                }
+
                 return $branch;
             }
 

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -7,7 +7,6 @@ namespace Doctrine\AutomaticReleases\Git\Value;
 use Assert\Assert;
 use function array_filter;
 use function array_search;
-use function array_values;
 use function assert;
 use function end;
 use function is_int;
@@ -53,23 +52,21 @@ final class MergeTargetCandidateBranches
 
     public function targetBranchFor(SemVerVersion $version) : ?BranchName
     {
-        return array_values(array_filter(
-            $this->sortedBranches,
-            static function (BranchName $branch) use ($version) : bool {
-                    return ! $branch->isNextMajor()
-                        && $branch->majorAndMinor() === [$version->major(), $version->minor()];
+        foreach ($this->sortedBranches as $branch) {
+            if ($branch->isNextMajor()) {
+                return $branch;
             }
-        ))[0] ?? $this->nextMajorBranch();
-    }
 
-    private function nextMajorBranch() : ?BranchName
-    {
-        return array_values(array_filter(
-            $this->sortedBranches,
-            static function (BranchName $branch) : bool {
-                return $branch->isNextMajor();
+            if ($branch->isForNewerVersionThan($version)) {
+                return null;
             }
-        ))[0] ?? null;
+
+            if ($branch->isForVersion($version)) {
+                return $branch;
+            }
+        }
+
+        return null;
     }
 
     public function branchToMergeUp(SemVerVersion $version) : ?BranchName

--- a/src/Git/Value/SemVerVersion.php
+++ b/src/Git/Value/SemVerVersion.php
@@ -61,4 +61,9 @@ final class SemVerVersion
     {
         return BranchName::fromName($this->major . '.' . $this->minor . '.x');
     }
+
+    public function isNewMinorRelease() : bool
+    {
+        return $this->patch === 0;
+    }
 }

--- a/src/Git/Value/SemVerVersion.php
+++ b/src/Git/Value/SemVerVersion.php
@@ -56,4 +56,9 @@ final class SemVerVersion
     {
         return $this->minor;
     }
+
+    public function targetReleaseBranchName() : BranchName
+    {
+        return BranchName::fromName($this->major . '.' . $this->minor . '.x');
+    }
 }

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -77,4 +77,11 @@ final class BranchNameTest extends TestCase
             ['33.44.x', 33, 44],
         ];
     }
+
+    public function testEquals() : void
+    {
+        self::assertFalse(BranchName::fromName('foo')->equals(BranchName::fromName('bar')));
+        self::assertFalse(BranchName::fromName('bar')->equals(BranchName::fromName('foo')));
+        self::assertTrue(BranchName::fromName('foo')->equals(BranchName::fromName('foo')));
+    }
 }

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\AutomaticReleases\Test\Unit\Git\Value;
 
 use Assert\AssertionFailedException;
 use Doctrine\AutomaticReleases\Git\Value\BranchName;
+use Doctrine\AutomaticReleases\Git\Value\SemVerVersion;
 use PHPUnit\Framework\TestCase;
 
 final class BranchNameTest extends TestCase
@@ -83,5 +84,66 @@ final class BranchNameTest extends TestCase
         self::assertFalse(BranchName::fromName('foo')->equals(BranchName::fromName('bar')));
         self::assertFalse(BranchName::fromName('bar')->equals(BranchName::fromName('foo')));
         self::assertTrue(BranchName::fromName('foo')->equals(BranchName::fromName('foo')));
+    }
+
+    /**
+     * @dataProvider versionEqualityProvider
+     */
+    public function testIsForVersion(string $milestoneName, string $branchName, bool $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            BranchName::fromName($branchName)
+                ->isForVersion(SemVerVersion::fromMilestoneName($milestoneName))
+        );
+    }
+
+    /**
+     * @return array<int, array<int, bool|string>>
+     *
+     * @psalm-return array<int, array{0: string, 1: string, 2: bool}>
+     */
+    public function versionEqualityProvider() : array
+    {
+        return [
+            ['1.0.0', '1.0.x', true],
+            ['1.0.0', '1.1.x', false],
+            ['1.0.0', '0.9.x', false],
+            ['2.0.0', '1.0.x', false],
+            ['2.0.0', '2.0.x', true],
+            ['2.0.0', '2.0', true],
+            ['2.0.0', '2.1', false],
+        ];
+    }
+
+    /**
+     * @dataProvider newerVersionComparisonProvider
+     */
+    public function testIsForNewerVersionThan(string $milestoneName, string $branchName, bool $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            BranchName::fromName($branchName)
+                ->isForNewerVersionThan(SemVerVersion::fromMilestoneName($milestoneName))
+        );
+    }
+
+    /**
+     * @return array<int, array<int, bool|string>>
+     *
+     * @psalm-return array<int, array{0: string, 1: string, 2: bool}>
+     */
+    public function newerVersionComparisonProvider() : array
+    {
+        return [
+            ['1.0.0', '1.0.x', false],
+            ['1.0.0', '1.1.x', true],
+            ['1.0.0', '0.9.x', false],
+            ['2.0.0', '1.0.x', false],
+            ['2.0.0', '2.0.x', false],
+            ['2.0.0', '2.0', false],
+            ['2.0.0', '2.1', true],
+            ['2.0.0', '1.9', false],
+        ];
     }
 }

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -23,17 +23,17 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             BranchName::fromName('1.5')
         );
 
-        self::assertNull($branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.99.0')));
         self::assertEquals(
             BranchName::fromName('master'),
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.99.0'))
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.99.0'))
         );
+        self::assertNull($branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.99.0')));
 
-        self::assertNull($branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0')));
         self::assertEquals(
             BranchName::fromName('master'),
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0'))
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0'))
         );
+        self::assertNull($branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0')));
 
         self::assertEquals(
             BranchName::fromName('1.2'),
@@ -52,6 +52,10 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             BranchName::fromName('master'),
             $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.5.99'))
         );
+        self::assertEquals(
+            BranchName::fromName('master'),
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.6.0'))
+        );
 
         self::assertEquals(
             BranchName::fromName('1.0'),
@@ -60,6 +64,74 @@ final class MergeTargetCandidateBranchesTest extends TestCase
         self::assertEquals(
             BranchName::fromName('1.1'),
             $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.0.1'))
+        );
+    }
+
+    public function testCannotGetNextMajorBranchIfNoneExists() : void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1'),
+            BranchName::fromName('1.2'),
+            BranchName::fromName('potato')
+        );
+
+        self::assertNull(
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.6.0')),
+            'Cannot release next minor, since next minor branch does not exist'
+        );
+        self::assertNull(
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.6.0')),
+            'Cannot merge up next minor, since no next branch exists'
+        );
+        self::assertNull(
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0')),
+            'Cannot release next major, since next major branch does not exist'
+        );
+        self::assertNull(
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0')),
+            'Cannot merge up next major, since no next branch exists'
+        );
+        self::assertNull(
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.2.1')),
+            'Cannot merge up: no master branch exists'
+        );
+    }
+
+    public function testWillPickNewMajorReleaseBranchIfNoCurrentReleaseBranchExists() : void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1'),
+            BranchName::fromName('1.2'),
+            BranchName::fromName('master')
+        );
+
+        self::assertEquals(
+            BranchName::fromName('1.2'),
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.2.31')),
+            'Next patch release will be tagged from active minor branch'
+        );
+        self::assertEquals(
+            BranchName::fromName('master'),
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.2.31')),
+            '1.2.x will be merged into master'
+        );
+        self::assertEquals(
+            BranchName::fromName('master'),
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.3.0')),
+            'Next minor release will be tagged from active master branch'
+        );
+        self::assertNull(
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.3.0')),
+            '1.3.0 won\'t be merged up, since there\'s no further branches to merge to'
+        );
+        self::assertEquals(
+            BranchName::fromName('master'),
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0')),
+            'Next major release will be tagged from active master branch'
+        );
+        self::assertNull(
+            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0')),
+            '2.0.0 won\'t be merged up, since there\'s no further branches to merge to'
         );
     }
 }

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -134,4 +134,18 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             '2.0.0 won\'t be merged up, since there\'s no further branches to merge to'
         );
     }
+
+    /** @link https://github.com/doctrine/automatic-releases/pull/23#discussion_r344499867 */
+    public function testWillNotPickTargetIfNoMatchingReleaseBranchAndNewerReleaseBranchesExist() : void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.2.x'),
+            BranchName::fromName('master')
+        );
+
+        self::assertNull(
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.1.0')),
+            '1.1.0 can\'t have a target branch, since 1.2.x already exists'
+        );
+    }
 }

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -148,4 +148,18 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             '1.1.0 can\'t have a target branch, since 1.2.x already exists'
         );
     }
+
+    /** @link https://github.com/doctrine/automatic-releases/pull/23#discussion_r344499867 */
+    public function testWillNotPickPatchTargetIfNoMatchingReleaseBranchAndNewerReleaseBranchesExist() : void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.0.x'),
+            BranchName::fromName('master')
+        );
+
+        self::assertNull(
+            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.1.1')),
+            '1.1.1 can\'t have a target branch, since 1.1.x doesn\'t exist, but patches require a release branch'
+        );
+    }
 }

--- a/test/unit/Git/Value/SemVerVersionTest.php
+++ b/test/unit/Git/Value/SemVerVersionTest.php
@@ -89,4 +89,33 @@ final class SemVerVersionTest extends TestCase
             ['99.99.99', '99.99.x'],
         ];
     }
+
+    /**
+     * @dataProvider newMinorReleasesProvider
+     */
+    public function testIsNewMinorRelease(string $milestoneName, bool $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            SemVerVersion::fromMilestoneName($milestoneName)
+                ->isNewMinorRelease()
+        );
+    }
+
+    /**
+     * @return array<int, array<int, string|bool>>
+     *
+     * @psalm-return array<int, array{0: string, 1: bool}>
+     */
+    public function newMinorReleasesProvider() : array
+    {
+        return [
+            ['1.0.0', true],
+            ['1.1.0', true],
+            ['1.1.1', false],
+            ['1.1.2', false],
+            ['1.1.90', false],
+            ['0.9.0', true],
+        ];
+    }
 }

--- a/test/unit/Git/Value/SemVerVersionTest.php
+++ b/test/unit/Git/Value/SemVerVersionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\AutomaticReleases\Test\Unit\Git\Value;
 
 use Assert\AssertionFailedException;
+use Doctrine\AutomaticReleases\Git\Value\BranchName;
 use Doctrine\AutomaticReleases\Git\Value\SemVerVersion;
 use PHPUnit\Framework\TestCase;
 
@@ -64,6 +65,28 @@ final class SemVerVersionTest extends TestCase
             ['potato'],
             ['1.2.'],
             ['1.2'],
+        ];
+    }
+
+    /**
+     * @dataProvider releaseBranchNames
+     */
+    public function testReleaseBranchNames(string $milestoneName, string $expectedTargetBranch) : void
+    {
+        self::assertEquals(
+            BranchName::fromName($expectedTargetBranch),
+            SemVerVersion::fromMilestoneName($milestoneName)
+                ->targetReleaseBranchName()
+        );
+    }
+
+    /** @return array<int, array<int, string>> */
+    public function releaseBranchNames() : array
+    {
+        return [
+            ['1.2.3', '1.2.x'],
+            ['2.0.0', '2.0.x'],
+            ['99.99.99', '99.99.x'],
         ];
     }
 }


### PR DESCRIPTION
This patch fixes some behavior that was quite annoying when dealing with the `roave/*` packages, which I've just configured to use this tool (with a separate environment, using a private GPG subkey by @asgrim).

Specifically, imagine this scenario (also common to the `doctrine/*` packages):

 * `1.1.x` branch
 * `master` branch
 * `1.2.0` milestone

With the setup above, closing milestone `1.2.0` will lead to a crash of the tool, because it cannot find an `1.2.x` branch where to create the tag from.

This patch fixes that. In the scenario above:

 * it will create tag `1.2.0` from `master`
 * it will create an `1.2.x` branch

This seems to be very much compatible with our workflow, since (besides deprecated `Version::` constants) we can safely release new minors from `master`, if BC compliance matches.

Note that this will also allow us to release `2.0.0` from `master`, which previously had to be done manually.

@alcaeus to you specifically (since you asked) I don't think making the tool configurable is a good approach, since it should be opinionated and matching our own workflow (instead of becoming a tool we maintain for the community). If this isn't an approach that applies to `doctrine/*` (I think it is, but @doctrine/doctrinecore has to decide), I'm OK with maintaining my fork of it for `roave/*`.