### PR TITLE
Set correct branch name for new release

### DIFF
--- a/src/Github/Api/V3/CreateRelease.php
+++ b/src/Github/Api/V3/CreateRelease.php
@@ -60,9 +60,10 @@ final class CreateRelease
         $request
             ->getBody()
             ->write(json_encode([
-                'tag_name' => $version->fullReleaseName(),
-                'name'     => $version->fullReleaseName(),
-                'body'     => $releaseNotes,
+                'tag_name'         => $version->fullReleaseName(),
+                'name'             => $version->fullReleaseName(),
+                'target_commitish' => $version->targetReleaseBranchName()->name(),
+                'body'             => $releaseNotes,
             ]));
 
         $response = $this->client->sendRequest($request);

--- a/test/unit/Github/Api/V3/CreateReleaseTest.php
+++ b/test/unit/Github/Api/V3/CreateReleaseTest.php
@@ -82,6 +82,7 @@ JSON
 {
     "tag_name": "1.2.3",
     "name": "1.2.3",
+    "target_commitish": "1.2.x",
     "body": "the-body"
 }
 JSON


### PR DESCRIPTION
This will fix the following information on the release page:
![image](https://user-images.githubusercontent.com/383198/82834827-8dea2d80-9ec2-11ea-9701-623d90bfcd43.png)

The message should read
> (x) commits to 1.10.x since this release

`target_commitish` defaults to "master", but can be any commit. If the tag doesn't exist, it would be created from the branch given, but that would not affect this tool as it creates signed tags before creating a release.