### PR TITLE
Revert "Set correct branch name for new release"

### DIFF
--- a/src/Github/Api/V3/CreateRelease.php
+++ b/src/Github/Api/V3/CreateRelease.php
@@ -60,10 +60,9 @@ final class CreateRelease
         $request
             ->getBody()
             ->write(json_encode([
-                'tag_name'         => $version->fullReleaseName(),
-                'name'             => $version->fullReleaseName(),
-                'target_commitish' => $version->targetReleaseBranchName()->name(),
-                'body'             => $releaseNotes,
+                'tag_name' => $version->fullReleaseName(),
+                'name'     => $version->fullReleaseName(),
+                'body'     => $releaseNotes,
             ]));
 
         $response = $this->client->sendRequest($request);

--- a/test/unit/Github/Api/V3/CreateReleaseTest.php
+++ b/test/unit/Github/Api/V3/CreateReleaseTest.php
@@ -82,7 +82,6 @@ JSON
 {
     "tag_name": "1.2.3",
     "name": "1.2.3",
-    "target_commitish": "1.2.x",
     "body": "the-body"
 }
 JSON


### PR DESCRIPTION
Reverts doctrine/automatic-releases#62. For some reason, this only worked in a single repository, so I'm rolling this back for now.